### PR TITLE
chat.meta.SO is now chat.meta.SE

### DIFF
--- a/ChatMods.user.js
+++ b/ChatMods.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Chat Mods
 // @description  Modifications and bug fixes for StackExchange's chat rooms
-// @match        *://chat.meta.stackoverflow.com/*
+// @match        *://chat.meta.stackexchange.com/*
 // @match        *://chat.stackexchange.com/*
 // @match        *://chat.stackoverflow.com/*
 // @match        *://chat.askubuntu.com/*


### PR DESCRIPTION
The script didn't work on `chat.meta.stackexchange.com`, since the `@match` directive was still `chat.meta.stackoverflow.com`.